### PR TITLE
Correct the range of the log1p polynomial

### DIFF
--- a/include/boost/decimal/detail/cmath/impl/log1p_impl.hpp
+++ b/include/boost/decimal/detail/cmath/impl/log1p_impl.hpp
@@ -26,185 +26,157 @@ template <bool b>
 struct log1p_table_imp
 {
 private:
-    using d32_coeffs_t  = std::array<decimal32_t,  12>;
-    using d64_coeffs_t  = std::array<decimal64_t,  20>;
-    using d128_coeffs_t = std::array<decimal128_t, 36>;
+    using d32_coeffs_t  = std::array<decimal32_t,   7>;
+    using d64_coeffs_t  = std::array<decimal64_t,  16>;
+    using d128_coeffs_t = std::array<decimal128_t, 34>;
 
-    using d32_fast_coeffs_t  = std::array<decimal_fast32_t,  12>;
-    using d64_fast_coeffs_t  = std::array<decimal_fast64_t,  20>;
-    using d128_fast_coeffs_t = std::array<decimal_fast128_t, 36>;
+    using d32_fast_coeffs_t  = std::array<decimal_fast32_t,   7>;
+    using d64_fast_coeffs_t  = std::array<decimal_fast64_t,  16>;
+    using d128_fast_coeffs_t = std::array<decimal_fast128_t, 34>;
 
 public:
     static constexpr d32_coeffs_t d32_coeffs =
     {{
-         // Series[Log[1 + x], {x, 0, 13}]
-         //            (1),                                                     // * z
-         -boost::decimal::decimal32_t { 5, -1 },                                  // * z^2
-          boost::decimal::decimal32_t { UINT64_C(3333333333333333333), -19 },     // * z^3
-         -boost::decimal::decimal32_t { 25, -2 },                                 // * z^4
-          boost::decimal::decimal32_t { 2, -1 },                                  // * z^5
-         -boost::decimal::decimal32_t { UINT64_C(1666666666666666667), -19 },     // * z^6
-          boost::decimal::decimal32_t { UINT64_C(1428571428571428571), -19 },     // * z^7
-         -boost::decimal::decimal32_t { 125, -3 },                                // * z^8
-          boost::decimal::decimal32_t { UINT64_C(1111111111111111111), -19 },     // * z^9
-         -boost::decimal::decimal32_t { 1, -1 },                                  // * z^10
-          boost::decimal::decimal32_t { UINT64_C(9090909090909090909), -19 - 1 }, // * z^11
-         -boost::decimal::decimal32_t { UINT64_C(8333333333333333333), -19 - 1 }, // * z^12
-          boost::decimal::decimal32_t { UINT64_C(7692307692307692308), -19 - 1 }, // * z^13
+         // Series[2*ArcTanh[w], {w, 0, 13}]
+         boost::decimal::decimal32_t { 2, 0 },                               // * w^1
+         boost::decimal::decimal32_t { UINT64_C(6666666666666666667), -19 }, // * w^3
+         boost::decimal::decimal32_t { UINT64_C(4000000000000000000), -19 }, // * w^5
+         boost::decimal::decimal32_t { UINT64_C(2857142857142857143), -19 }, // * w^7
+         boost::decimal::decimal32_t { UINT64_C(2222222222222222222), -19 }, // * w^9
+         boost::decimal::decimal32_t { UINT64_C(1818181818181818182), -19 }, // * w^11
+         boost::decimal::decimal32_t { UINT64_C(1538461538461538462), -19 }, // * w^13
     }};
 
     static constexpr d32_fast_coeffs_t d32_fast_coeffs =
     {{
-         // Series[Log[1 + x], {x, 0, 13}]
-         //            (1),                                                     // * z
-         -boost::decimal::decimal_fast32_t { 5, -1 },                                  // * z^2
-          boost::decimal::decimal_fast32_t { UINT64_C(3333333333333333333), -19 },     // * z^3
-         -boost::decimal::decimal_fast32_t { 25, -2 },                                 // * z^4
-          boost::decimal::decimal_fast32_t { 2, -1 },                                  // * z^5
-         -boost::decimal::decimal_fast32_t { UINT64_C(1666666666666666667), -19 },     // * z^6
-          boost::decimal::decimal_fast32_t { UINT64_C(1428571428571428571), -19 },     // * z^7
-         -boost::decimal::decimal_fast32_t { 125, -3 },                                // * z^8
-          boost::decimal::decimal_fast32_t { UINT64_C(1111111111111111111), -19 },     // * z^9
-         -boost::decimal::decimal_fast32_t { 1, -1 },                                  // * z^10
-          boost::decimal::decimal_fast32_t { UINT64_C(9090909090909090909), -19 - 1 }, // * z^11
-         -boost::decimal::decimal_fast32_t { UINT64_C(8333333333333333333), -19 - 1 }, // * z^12
-          boost::decimal::decimal_fast32_t { UINT64_C(7692307692307692308), -19 - 1 }, // * z^13
-     }};
+         // Series[2*ArcTanh[w], {w, 0, 13}]
+         boost::decimal::decimal_fast32_t { 2, 0 },                               // * w^1
+         boost::decimal::decimal_fast32_t { UINT64_C(6666666666666666667), -19 }, // * w^3
+         boost::decimal::decimal_fast32_t { UINT64_C(4000000000000000000), -19 }, // * w^5
+         boost::decimal::decimal_fast32_t { UINT64_C(2857142857142857143), -19 }, // * w^7
+         boost::decimal::decimal_fast32_t { UINT64_C(2222222222222222222), -19 }, // * w^9
+         boost::decimal::decimal_fast32_t { UINT64_C(1818181818181818182), -19 }, // * w^11
+         boost::decimal::decimal_fast32_t { UINT64_C(1538461538461538462), -19 }, // * w^13
+    }};
 
     static constexpr d64_coeffs_t d64_coeffs =
     {{
-         // Series[Log[1 + x], {x, 0, 21}]
-         //            (1),                                                     // * z
-         -boost::decimal::decimal64_t { 5, -1 },                                  // * z^2
-          boost::decimal::decimal64_t { UINT64_C(3333333333333333333), -19 },     // * z^3
-         -boost::decimal::decimal64_t { 25, -2 },                                 // * z^4
-          boost::decimal::decimal64_t { 2, -1 },                                  // * z^5
-         -boost::decimal::decimal64_t { UINT64_C(1666666666666666667), -19 },     // * z^6
-          boost::decimal::decimal64_t { UINT64_C(1428571428571428571), -19 },     // * z^7
-         -boost::decimal::decimal64_t { 125, -3 },                                // * z^8
-          boost::decimal::decimal64_t { UINT64_C(1111111111111111111), -19 },     // * z^9
-         -boost::decimal::decimal64_t { 1, -1 },                                  // * z^10
-          boost::decimal::decimal64_t { UINT64_C(9090909090909090909), -19 - 1 }, // * z^11
-         -boost::decimal::decimal64_t { UINT64_C(8333333333333333333), -19 - 1 }, // * z^12
-          boost::decimal::decimal64_t { UINT64_C(7692307692307692308), -19 - 1 }, // * z^13
-         -boost::decimal::decimal64_t { UINT64_C(7142857142857142857), -19 - 1 }, // * z^14
-          boost::decimal::decimal64_t { UINT64_C(6666666666666666667), -19 - 1 }, // * z^15
-         -boost::decimal::decimal64_t { UINT64_C(6250000000000000000), -19 - 1 }, // * z^16
-          boost::decimal::decimal64_t { UINT64_C(5882352941176470588), -19 - 1 }, // * z^17
-         -boost::decimal::decimal64_t { UINT64_C(5555555555555555556), -19 - 1 }, // * z^18
-          boost::decimal::decimal64_t { UINT64_C(5263157894736842105), -19 - 1 }, // * z^19
-         -boost::decimal::decimal64_t { 5, -2 },                                  // * z^20
-          boost::decimal::decimal64_t { UINT64_C(4761904761904761905), -19 - 1 }, // * z^21
-     }};
+         // Series[2*ArcTanh[w], {w, 0, 31}]
+         boost::decimal::decimal64_t { 2, 0 },                                   // * w^1
+         boost::decimal::decimal64_t { UINT64_C(6666666666666666667), -19 },     // * w^3
+         boost::decimal::decimal64_t { UINT64_C(4000000000000000000), -19 },     // * w^5
+         boost::decimal::decimal64_t { UINT64_C(2857142857142857143), -19 },     // * w^7
+         boost::decimal::decimal64_t { UINT64_C(2222222222222222222), -19 },     // * w^9
+         boost::decimal::decimal64_t { UINT64_C(1818181818181818182), -19 },     // * w^11
+         boost::decimal::decimal64_t { UINT64_C(1538461538461538462), -19 },     // * w^13
+         boost::decimal::decimal64_t { UINT64_C(1333333333333333333), -19 },     // * w^15
+         boost::decimal::decimal64_t { UINT64_C(1176470588235294118), -19 },     // * w^17
+         boost::decimal::decimal64_t { UINT64_C(1052631578947368421), -19 },     // * w^19
+         boost::decimal::decimal64_t { UINT64_C(9523809523809523810), -19 - 1 }, // * w^21
+         boost::decimal::decimal64_t { UINT64_C(8695652173913043478), -19 - 1 }, // * w^23
+         boost::decimal::decimal64_t { UINT64_C(8000000000000000000), -19 - 1 }, // * w^25
+         boost::decimal::decimal64_t { UINT64_C(7407407407407407407), -19 - 1 }, // * w^27
+         boost::decimal::decimal64_t { UINT64_C(6896551724137931034), -19 - 1 }, // * w^29
+         boost::decimal::decimal64_t { UINT64_C(6451612903225806452), -19 - 1 }, // * w^31
+    }};
 
     static constexpr d64_fast_coeffs_t d64_fast_coeffs =
     {{
-         // Series[Log[1 + x], {x, 0, 21}]
-         //            (1),                                                     // * z
-         -boost::decimal::decimal_fast64_t { 5, -1 },                                  // * z^2
-          boost::decimal::decimal_fast64_t { UINT64_C(3333333333333333333), -19 },     // * z^3
-         -boost::decimal::decimal_fast64_t { 25, -2 },                                 // * z^4
-          boost::decimal::decimal_fast64_t { 2, -1 },                                  // * z^5
-         -boost::decimal::decimal_fast64_t { UINT64_C(1666666666666666667), -19 },     // * z^6
-          boost::decimal::decimal_fast64_t { UINT64_C(1428571428571428571), -19 },     // * z^7
-         -boost::decimal::decimal_fast64_t { 125, -3 },                                // * z^8
-          boost::decimal::decimal_fast64_t { UINT64_C(1111111111111111111), -19 },     // * z^9
-         -boost::decimal::decimal_fast64_t { 1, -1 },                                  // * z^10
-          boost::decimal::decimal_fast64_t { UINT64_C(9090909090909090909), -19 - 1 }, // * z^11
-         -boost::decimal::decimal_fast64_t { UINT64_C(8333333333333333333), -19 - 1 }, // * z^12
-          boost::decimal::decimal_fast64_t { UINT64_C(7692307692307692308), -19 - 1 }, // * z^13
-         -boost::decimal::decimal_fast64_t { UINT64_C(7142857142857142857), -19 - 1 }, // * z^14
-          boost::decimal::decimal_fast64_t { UINT64_C(6666666666666666667), -19 - 1 }, // * z^15
-         -boost::decimal::decimal_fast64_t { UINT64_C(6250000000000000000), -19 - 1 }, // * z^16
-          boost::decimal::decimal_fast64_t { UINT64_C(5882352941176470588), -19 - 1 }, // * z^17
-         -boost::decimal::decimal_fast64_t { UINT64_C(5555555555555555556), -19 - 1 }, // * z^18
-          boost::decimal::decimal_fast64_t { UINT64_C(5263157894736842105), -19 - 1 }, // * z^19
-         -boost::decimal::decimal_fast64_t { 5, -2 },                                  // * z^20
-          boost::decimal::decimal_fast64_t { UINT64_C(4761904761904761905), -19 - 1 }, // * z^21
-     }};
+         // Series[2*ArcTanh[w], {w, 0, 31}]
+         boost::decimal::decimal_fast64_t { 2, 0 },                                   // * w^1
+         boost::decimal::decimal_fast64_t { UINT64_C(6666666666666666667), -19 },     // * w^3
+         boost::decimal::decimal_fast64_t { UINT64_C(4000000000000000000), -19 },     // * w^5
+         boost::decimal::decimal_fast64_t { UINT64_C(2857142857142857143), -19 },     // * w^7
+         boost::decimal::decimal_fast64_t { UINT64_C(2222222222222222222), -19 },     // * w^9
+         boost::decimal::decimal_fast64_t { UINT64_C(1818181818181818182), -19 },     // * w^11
+         boost::decimal::decimal_fast64_t { UINT64_C(1538461538461538462), -19 },     // * w^13
+         boost::decimal::decimal_fast64_t { UINT64_C(1333333333333333333), -19 },     // * w^15
+         boost::decimal::decimal_fast64_t { UINT64_C(1176470588235294118), -19 },     // * w^17
+         boost::decimal::decimal_fast64_t { UINT64_C(1052631578947368421), -19 },     // * w^19
+         boost::decimal::decimal_fast64_t { UINT64_C(9523809523809523810), -19 - 1 }, // * w^21
+         boost::decimal::decimal_fast64_t { UINT64_C(8695652173913043478), -19 - 1 }, // * w^23
+         boost::decimal::decimal_fast64_t { UINT64_C(8000000000000000000), -19 - 1 }, // * w^25
+         boost::decimal::decimal_fast64_t { UINT64_C(7407407407407407407), -19 - 1 }, // * w^27
+         boost::decimal::decimal_fast64_t { UINT64_C(6896551724137931034), -19 - 1 }, // * w^29
+         boost::decimal::decimal_fast64_t { UINT64_C(6451612903225806452), -19 - 1 }, // * w^31
+    }};
 
     static constexpr d128_coeffs_t d128_coeffs =
     {{
-         // Series[Log[(1 + (z/2))/(1 - (z/2))], {z, 0, 43}]
-         //            (1),                                                                                                                    // * z
-         -::boost::decimal::decimal128_t { 5, -1 },                                                                                              // * z^2
-          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(180700362080917), UINT64_C(7483252092553221458)  }, -34 }, // * z^3
-         -::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(135525271560688), UINT64_C(1000753050987528192)  }, -34 }, // * z^4
-          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(108420217248550), UINT64_C(8179300070273843200)  }, -34 }, // * z^5
-         -::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(90350181040458),  UINT64_C(12964998083131386532) }, -34 }, // * z^6
-          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(77443012320393),  UINT64_C(3207108039665666332)  }, -34 }, // * z^7
-         -::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(67762635780344),  UINT64_C(500376525493764096)   }, -34 }, // * z^8
-          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(60233454026972),  UINT64_C(8643332055420924359)  }, -34 }, // * z^9
-         -::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(54210108624275),  UINT64_C(4089650035136921600)  }, -34 }, // * z^10
-          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(492819169311592), UINT64_C(17054915875379776418) }, -35 }, // * z^11
-         -::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(451750905202293), UINT64_C(9484758194528277842)  }, -35 }, // * z^12
-          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(417000835571347), UINT64_C(15850062977145160938) }, -35 }, // * z^13
-         -::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(387215061601965), UINT64_C(16035540198328331700) }, -35 }, // * z^14
-          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(361400724161834), UINT64_C(14966504185106442916) }, -35 }, // * z^15
-         -::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(338813178901720), UINT64_C(2501882627468820480)  }, -35 }, // * z^16
-          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(318882991907501), UINT64_C(5610020838860575434)  }, -35 }, // * z^17
-         -::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(301167270134862), UINT64_C(6323172129685518558)  }, -35 }, // * z^18
-          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(285316361180395), UINT64_C(16670067533954968520) }, -35 }, // * z^19
-         -::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(271050543121376), UINT64_C(2001506101975056384)  }, -35 }, // * z^20
-          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(258143374401310), UINT64_C(10690360132218887800) }, -35 }, // * z^21
-         -::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(246409584655796), UINT64_C(8527457937689888204)  }, -35 }, // * z^22
-          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(235696124453370), UINT64_C(9760763598982462770)  }, -35 }, // * z^23
-         -::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(225875452601146), UINT64_C(13965751134118914724) }, -35 }, // * z^24
-          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(216840434497100), UINT64_C(16358600140547686400) }, -35 }, // * z^25
-         -::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(208500417785673), UINT64_C(17148403525427356272) }, -35 }, // * z^26
-          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(200778180089908), UINT64_C(4215448086457012372)  }, -35 }, // * z^27
-         -::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(193607530800982), UINT64_C(17241142136018941658) }, -35 }, // * z^28
-          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(186931409049224), UINT64_C(16646619993397598836) }, -35 }, // * z^29
-         -::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(180700362080917), UINT64_C(7483252092553221458)  }, -35 }, // * z^30
-          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(174871318142823), UINT64_C(5456688082434451252)  }, -35 }, // * z^31
-         -::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(169406589450860), UINT64_C(1250941313734410240)  }, -35 }, // * z^32
-          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(164273056437197), UINT64_C(11833886649696442678) }, -35 }, // * z^33
-         -::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(159441495953750), UINT64_C(12028382456285063520) }, -35 }, // * z^34
-          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(154886024640786), UINT64_C(6414216079331332674)  }, -35 }, // * z^35
-         -::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(150583635067431), UINT64_C(3161586064842759274)  }, -35 }, // * z^36
-          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(146513807092635), UINT64_C(13545911456276754540) }, -35 }, // * z^37
+         // Series[2*ArcTanh[w], {w, 0, 67}]
+         ::boost::decimal::decimal128_t { 2, 0 },                                                                                        // * w^1
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(361400724161834), UINT64_C(14966504185106442923) }, -34 }, // * w^3
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(216840434497100), UINT64_C(16358600140547686400) }, -34 }, // * w^5
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(154886024640786), UINT64_C(6414216079331332681) }, -34 },  // * w^7
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(120466908053944), UINT64_C(17286664110841848718) }, -34 }, // * w^9
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(98563833862318), UINT64_C(10789680804559775930) }, -34 },  // * w^11
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(83400167114269), UINT64_C(10548710224912852834) }, -34 },  // * w^13
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(72280144832366), UINT64_C(17750696095988929877) }, -34 },  // * w^15
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(63776598381500), UINT64_C(4811352982514025412) }, -34 },   // * w^17
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(57063272236079), UINT64_C(3334013506790993704) }, -34 },   // * w^19
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(516286748802621), UINT64_C(2933976190728223988) }, -35 },  // * w^21
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(471392248906741), UINT64_C(1074783124255373935) }, -35 },  // * w^23
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(433680868994201), UINT64_C(14270456207385821184) }, -35 }, // * w^25
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(401556360179816), UINT64_C(8430896172914024751) }, -35 },  // * w^27
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(373862818098449), UINT64_C(14846495913085646071) }, -35 }, // * w^29
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(349742636285646), UINT64_C(10913376164868902516) }, -35 }, // * w^31
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(328546112874395), UINT64_C(5221029225683333741) }, -35 },  // * w^33
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(309772049281572), UINT64_C(12828432158662665362) }, -35 }, // * w^35
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(293027614185271), UINT64_C(8645078838843957469) }, -35 },  // * w^37
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(278000557047565), UINT64_C(4417793960193590088) }, -35 },  // * w^39
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(264439554264757), UINT64_C(3302450641466607566) }, -35 },  // * w^41
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(252140040112908), UINT64_C(145889948468931370) }, -35 },   // * w^43
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(240933816107889), UINT64_C(16126584147974145820) }, -35 }, // * w^45
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(230681313294788), UINT64_C(3273345114337031103) }, -35 },  // * w^47
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(221265749486837), UINT64_C(11798414981003268347) }, -35 }, // * w^49
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(212588661271667), UINT64_C(9888928583810234167) }, -35 },  // * w^51
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(204566447638774), UINT64_C(7775502592561777065) }, -35 },  // * w^53
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(197127667724637), UINT64_C(3132617535410000244) }, -35 },  // * w^55
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(190210907453597), UINT64_C(4964463664733461809) }, -35 },  // * w^57
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(183763080082288), UINT64_C(16364473891814588694) }, -35 }, // * w^59
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(177738061063197), UINT64_C(8267792750398720369) }, -35 },  // * w^61
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(172095582934207), UINT64_C(977992063576074663) }, -35 },   // * w^63
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(166800334228539), UINT64_C(2650676376116154053) }, -35 },  // * w^65
+         ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(161821219773955), UINT64_C(16337778628851158123) }, -35 }, // * w^67
     }};
 
     static constexpr d128_fast_coeffs_t d128_fast_coeffs =
     {{
-        // Series[Log[(1 + (z/2))/(1 - (z/2))], {z, 0, 43}]
-        //            (1),                                                                                                                    // * z
-        -::boost::decimal::decimal_fast128_t { 5, -1 },                                                                                              // * z^2
-         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(180700362080917), UINT64_C(7483252092553221458)  }, -34 }, // * z^3
-        -::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(135525271560688), UINT64_C(1000753050987528192)  }, -34 }, // * z^4
-         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(108420217248550), UINT64_C(8179300070273843200)  }, -34 }, // * z^5
-        -::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(90350181040458),  UINT64_C(12964998083131386532) }, -34 }, // * z^6
-         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(77443012320393),  UINT64_C(3207108039665666332)  }, -34 }, // * z^7
-        -::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(67762635780344),  UINT64_C(500376525493764096)   }, -34 }, // * z^8
-         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(60233454026972),  UINT64_C(8643332055420924359)  }, -34 }, // * z^9
-        -::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(54210108624275),  UINT64_C(4089650035136921600)  }, -34 }, // * z^10
-         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(492819169311592), UINT64_C(17054915875379776418) }, -35 }, // * z^11
-        -::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(451750905202293), UINT64_C(9484758194528277842)  }, -35 }, // * z^12
-         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(417000835571347), UINT64_C(15850062977145160938) }, -35 }, // * z^13
-        -::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(387215061601965), UINT64_C(16035540198328331700) }, -35 }, // * z^14
-         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(361400724161834), UINT64_C(14966504185106442916) }, -35 }, // * z^15
-        -::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(338813178901720), UINT64_C(2501882627468820480)  }, -35 }, // * z^16
-         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(318882991907501), UINT64_C(5610020838860575434)  }, -35 }, // * z^17
-        -::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(301167270134862), UINT64_C(6323172129685518558)  }, -35 }, // * z^18
-         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(285316361180395), UINT64_C(16670067533954968520) }, -35 }, // * z^19
-        -::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(271050543121376), UINT64_C(2001506101975056384)  }, -35 }, // * z^20
-         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(258143374401310), UINT64_C(10690360132218887800) }, -35 }, // * z^21
-        -::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(246409584655796), UINT64_C(8527457937689888204)  }, -35 }, // * z^22
-         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(235696124453370), UINT64_C(9760763598982462770)  }, -35 }, // * z^23
-        -::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(225875452601146), UINT64_C(13965751134118914724) }, -35 }, // * z^24
-         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(216840434497100), UINT64_C(16358600140547686400) }, -35 }, // * z^25
-        -::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(208500417785673), UINT64_C(17148403525427356272) }, -35 }, // * z^26
-         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(200778180089908), UINT64_C(4215448086457012372)  }, -35 }, // * z^27
-        -::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(193607530800982), UINT64_C(17241142136018941658) }, -35 }, // * z^28
-         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(186931409049224), UINT64_C(16646619993397598836) }, -35 }, // * z^29
-        -::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(180700362080917), UINT64_C(7483252092553221458)  }, -35 }, // * z^30
-         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(174871318142823), UINT64_C(5456688082434451252)  }, -35 }, // * z^31
-        -::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(169406589450860), UINT64_C(1250941313734410240)  }, -35 }, // * z^32
-         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(164273056437197), UINT64_C(11833886649696442678) }, -35 }, // * z^33
-        -::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(159441495953750), UINT64_C(12028382456285063520) }, -35 }, // * z^34
-         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(154886024640786), UINT64_C(6414216079331332674)  }, -35 }, // * z^35
-        -::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(150583635067431), UINT64_C(3161586064842759274)  }, -35 }, // * z^36
-         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(146513807092635), UINT64_C(13545911456276754540) }, -35 }, // * z^37
+         // Series[2*ArcTanh[w], {w, 0, 67}]
+         ::boost::decimal::decimal_fast128_t { 2, 0 },                                                                                        // * w^1
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(361400724161834), UINT64_C(14966504185106442923) }, -34 }, // * w^3
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(216840434497100), UINT64_C(16358600140547686400) }, -34 }, // * w^5
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(154886024640786), UINT64_C(6414216079331332681) }, -34 },  // * w^7
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(120466908053944), UINT64_C(17286664110841848718) }, -34 }, // * w^9
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(98563833862318), UINT64_C(10789680804559775930) }, -34 },  // * w^11
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(83400167114269), UINT64_C(10548710224912852834) }, -34 },  // * w^13
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(72280144832366), UINT64_C(17750696095988929877) }, -34 },  // * w^15
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(63776598381500), UINT64_C(4811352982514025412) }, -34 },   // * w^17
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(57063272236079), UINT64_C(3334013506790993704) }, -34 },   // * w^19
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(516286748802621), UINT64_C(2933976190728223988) }, -35 },  // * w^21
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(471392248906741), UINT64_C(1074783124255373935) }, -35 },  // * w^23
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(433680868994201), UINT64_C(14270456207385821184) }, -35 }, // * w^25
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(401556360179816), UINT64_C(8430896172914024751) }, -35 },  // * w^27
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(373862818098449), UINT64_C(14846495913085646071) }, -35 }, // * w^29
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(349742636285646), UINT64_C(10913376164868902516) }, -35 }, // * w^31
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(328546112874395), UINT64_C(5221029225683333741) }, -35 },  // * w^33
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(309772049281572), UINT64_C(12828432158662665362) }, -35 }, // * w^35
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(293027614185271), UINT64_C(8645078838843957469) }, -35 },  // * w^37
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(278000557047565), UINT64_C(4417793960193590088) }, -35 },  // * w^39
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(264439554264757), UINT64_C(3302450641466607566) }, -35 },  // * w^41
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(252140040112908), UINT64_C(145889948468931370) }, -35 },   // * w^43
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(240933816107889), UINT64_C(16126584147974145820) }, -35 }, // * w^45
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(230681313294788), UINT64_C(3273345114337031103) }, -35 },  // * w^47
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(221265749486837), UINT64_C(11798414981003268347) }, -35 }, // * w^49
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(212588661271667), UINT64_C(9888928583810234167) }, -35 },  // * w^51
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(204566447638774), UINT64_C(7775502592561777065) }, -35 },  // * w^53
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(197127667724637), UINT64_C(3132617535410000244) }, -35 },  // * w^55
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(190210907453597), UINT64_C(4964463664733461809) }, -35 },  // * w^57
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(183763080082288), UINT64_C(16364473891814588694) }, -35 }, // * w^59
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(177738061063197), UINT64_C(8267792750398720369) }, -35 },  // * w^61
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(172095582934207), UINT64_C(977992063576074663) }, -35 },   // * w^63
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(166800334228539), UINT64_C(2650676376116154053) }, -35 },  // * w^65
+         ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(161821219773955), UINT64_C(16337778628851158123) }, -35 }, // * w^67
     }};
 };
 

--- a/include/boost/decimal/detail/cmath/log1p.hpp
+++ b/include/boost/decimal/detail/cmath/log1p.hpp
@@ -7,6 +7,7 @@
 #define BOOST_DECIMAL_DETAIL_CMATH_LOG1P_HPP
 
 #include <boost/decimal/fwd.hpp> // NOLINT(llvm-include-order)
+#include <boost/decimal/detail/cmath/abs.hpp>
 #include <boost/decimal/detail/cmath/impl/log1p_impl.hpp>
 #include <boost/decimal/detail/concepts.hpp>
 #include <boost/decimal/detail/config.hpp>
@@ -59,13 +60,27 @@ constexpr auto log1p_impl(const T x) noexcept
     }
     else
     {
-        if (x > T { 5, -1 })
+        constexpr T small_argument { 1, -std::numeric_limits<T>::digits10 };
+
+        if (abs(x) < small_argument)
+        {
+            // log1p(x) = x - x^2/2 + ... For a value of |x| this small, the sum
+            // of the terms after x is less than one half of the last digit of x.
+            result = x;
+        }
+        else if (abs(x) > T { 5, -1 })
         {
             result = ::boost::decimal::log(x + one);
         }
         else
         {
-            result = x * fma(detail::log1p_series_expansion(x), x, one);
+            // log1p(x) = 2 * atanh(w), with w = x / (2 + x).
+            // For |x| not more than 1/2, the value of |w| is not more than 1/3.
+            // The coefficient table covers this range. For all larger values
+            // of |x|, the first branch calculates log(x + 1).
+            const T w { x / (T { 2, 0 } + x) };
+
+            result = w * detail::log1p_series_expansion(w * w);
         }
     }
 

--- a/test/test_acosh.cpp
+++ b/test/test_acosh.cpp
@@ -5,6 +5,7 @@
 
 #include "testing_config.hpp"
 #include <chrono>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -230,6 +231,56 @@ namespace local
     return result_is_ok;
   }
 
+  // These control values cover the range where this function gives an argument
+  // to log1p that is larger than its own argument. The random tests use
+  // decimal32_t and compare with float. Thus they cannot find an error that is
+  // smaller than the epsilon of float.
+  template<typename DecimalType>
+  auto test_acosh_ctrl(const int tol_factor) -> bool
+  {
+    using decimal_type = DecimalType;
+
+    using str_ctrl_array_type = std::array<const char*, 8U>;
+
+    const str_ctrl_array_type x_strings =
+    {{
+      "1.005", "1.01",  "1.02",  "1.03",
+      "1.05",  "1.08",  "1.1",   "1.2",
+    }};
+
+    const str_ctrl_array_type ctrl_strings =
+    {{
+      // Table[N[ArcCosh[x], 36], {x, x_strings}]
+      "0.0999583801386973304627899242727135732",
+      "0.141303769485648577351151646974354648",
+      "0.199668157798415126654606249409538887",
+      "0.244340698822827497531200999061269201",
+      "0.314924756603847871743403417928208223",
+      "0.397380220698482812949273831900413936",
+      "0.443568254385115189132911066352498087",
+      "0.62236250371477866780685115857913059",
+    }};
+
+    bool result_is_ok { true };
+
+    const decimal_type my_tol { std::numeric_limits<decimal_type>::epsilon() * static_cast<decimal_type>(tol_factor) };
+
+    for(auto i = static_cast<std::size_t>(UINT8_C(0)); i < std::tuple_size<str_ctrl_array_type>::value; ++i)
+    {
+      decimal_type x_arg      { };
+      decimal_type ctrl_value { };
+
+      static_cast<void>(from_chars(x_strings[i], x_strings[i] + std::strlen(x_strings[i]), x_arg));
+      static_cast<void>(from_chars(ctrl_strings[i], ctrl_strings[i] + std::strlen(ctrl_strings[i]), ctrl_value));
+
+      const auto result_acosh_is_ok = is_close_fraction(acosh(x_arg), ctrl_value, my_tol);
+
+      result_is_ok = (result_acosh_is_ok && result_is_ok);
+    }
+
+    return result_is_ok;
+  }
+
 } // namespace local
 
 auto main() -> int
@@ -264,6 +315,24 @@ auto main() -> int
   BOOST_TEST(result_edge_is_ok);
 
   result_is_ok = (result_edge_is_ok && result_is_ok);
+
+  {
+    using namespace boost::decimal;
+
+    const auto result_ctrl_is_ok =
+    (
+         local::test_acosh_ctrl<decimal32_t>      (16)
+      && local::test_acosh_ctrl<decimal64_t>      (16)
+      && local::test_acosh_ctrl<decimal128_t>     (16)
+      && local::test_acosh_ctrl<decimal_fast32_t> (16)
+      && local::test_acosh_ctrl<decimal_fast64_t> (16)
+      && local::test_acosh_ctrl<decimal_fast128_t>(16)
+    );
+
+    BOOST_TEST(result_ctrl_is_ok);
+
+    result_is_ok = (result_ctrl_is_ok && result_is_ok);
+  }
 
   result_is_ok = ((boost::report_errors() == 0) && result_is_ok);
 

--- a/test/test_asinh.cpp
+++ b/test/test_asinh.cpp
@@ -5,6 +5,7 @@
 
 #include "testing_config.hpp"
 #include <chrono>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -218,6 +219,60 @@ namespace local
     return result_is_ok;
   }
 
+  // These control values cover the range where this function gives an argument
+  // to log1p that is larger than its own argument. The random tests use
+  // decimal32_t and compare with float. Thus they cannot find an error that is
+  // smaller than the epsilon of float.
+  template<typename DecimalType>
+  auto test_asinh_ctrl(const int tol_factor) -> bool
+  {
+    using decimal_type = DecimalType;
+
+    using str_ctrl_array_type = std::array<const char*, 11U>;
+
+    const str_ctrl_array_type x_strings =
+    {{
+      "-0.45", "-0.35", "0.15",  "0.2",
+      "0.25",  "0.3",   "0.35",  "0.4",
+      "0.45",  "0.5",   "0.6",
+    }};
+
+    const str_ctrl_array_type ctrl_strings =
+    {{
+      // Table[N[ArcSinh[x], 36], {x, x_strings}]
+      "-0.436049668851740526505395726650547201",
+      "-0.343221555085943962127800239950427517",
+      "0.149443120184957656160285809150591369",
+      "0.198690110349241406474636915950206968",
+      "0.247466461547263452944781549788359289",
+      "0.295673047563422439102710529733517082",
+      "0.343221555085943962127800239950427517",
+      "0.390035319770715276080163379883629645",
+      "0.436049668851740526505395726650547201",
+      "0.481211825059603447497758913424368423",
+      "0.568824898732247530098688336861388356",
+    }};
+
+    bool result_is_ok { true };
+
+    const decimal_type my_tol { std::numeric_limits<decimal_type>::epsilon() * static_cast<decimal_type>(tol_factor) };
+
+    for(auto i = static_cast<std::size_t>(UINT8_C(0)); i < std::tuple_size<str_ctrl_array_type>::value; ++i)
+    {
+      decimal_type x_arg      { };
+      decimal_type ctrl_value { };
+
+      static_cast<void>(from_chars(x_strings[i], x_strings[i] + std::strlen(x_strings[i]), x_arg));
+      static_cast<void>(from_chars(ctrl_strings[i], ctrl_strings[i] + std::strlen(ctrl_strings[i]), ctrl_value));
+
+      const auto result_asinh_is_ok = is_close_fraction(asinh(x_arg), ctrl_value, my_tol);
+
+      result_is_ok = (result_asinh_is_ok && result_is_ok);
+    }
+
+    return result_is_ok;
+  }
+
 } // namespace local
 
 auto main() -> int
@@ -263,6 +318,24 @@ auto main() -> int
     && result_edge_is_ok
     && result_is_ok
   );
+
+  {
+    using namespace boost::decimal;
+
+    const auto result_ctrl_is_ok =
+    (
+         local::test_asinh_ctrl<decimal32_t>      (32)
+      && local::test_asinh_ctrl<decimal64_t>      (32)
+      && local::test_asinh_ctrl<decimal128_t>     (32)
+      && local::test_asinh_ctrl<decimal_fast32_t> (32)
+      && local::test_asinh_ctrl<decimal_fast64_t> (32)
+      && local::test_asinh_ctrl<decimal_fast128_t>(32)
+    );
+
+    BOOST_TEST(result_ctrl_is_ok);
+
+    result_is_ok = (result_ctrl_is_ok && result_is_ok);
+  }
 
   result_is_ok = ((boost::report_errors() == 0) && result_is_ok);
 

--- a/test/test_atanh.cpp
+++ b/test/test_atanh.cpp
@@ -5,6 +5,7 @@
 
 #include "testing_config.hpp"
 #include <chrono>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -232,6 +233,60 @@ namespace local
     return result_is_ok;
   }
 
+  // These control values cover the range where this function gives an argument
+  // to log1p that is larger than its own argument. The random tests use
+  // decimal32_t and compare with float. Thus they cannot find an error that is
+  // smaller than the epsilon of float.
+  template<typename DecimalType>
+  auto test_atanh_ctrl(const int tol_factor) -> bool
+  {
+    using decimal_type = DecimalType;
+
+    using str_ctrl_array_type = std::array<const char*, 11U>;
+
+    const str_ctrl_array_type x_strings =
+    {{
+      "-0.45", "-0.35", "-0.3",  "0.15",
+      "0.2",   "0.25",  "0.3",   "0.35",
+      "0.4",   "0.45",  "0.49",
+    }};
+
+    const str_ctrl_array_type ctrl_strings =
+    {{
+      // Table[N[ArcTanh[x], 36], {x, x_strings}]
+      "-0.484700278594051741560664227198391153",
+      "-0.365443754271396169066124134601129255",
+      "-0.309519604203111715474067349061069438",
+      "0.151140435936466805278609106968534791",
+      "0.202732554054082190989006557732174568",
+      "0.255412811882995341602757048151830967",
+      "0.309519604203111715474067349061069438",
+      "0.365443754271396169066124134601129255",
+      "0.423648930193601806855053753260327012",
+      "0.484700278594051741560664227198391153",
+      "0.536060336610566684673824210154234124",
+    }};
+
+    bool result_is_ok { true };
+
+    const decimal_type my_tol { std::numeric_limits<decimal_type>::epsilon() * static_cast<decimal_type>(tol_factor) };
+
+    for(auto i = static_cast<std::size_t>(UINT8_C(0)); i < std::tuple_size<str_ctrl_array_type>::value; ++i)
+    {
+      decimal_type x_arg      { };
+      decimal_type ctrl_value { };
+
+      static_cast<void>(from_chars(x_strings[i], x_strings[i] + std::strlen(x_strings[i]), x_arg));
+      static_cast<void>(from_chars(ctrl_strings[i], ctrl_strings[i] + std::strlen(ctrl_strings[i]), ctrl_value));
+
+      const auto result_atanh_is_ok = is_close_fraction(atanh(x_arg), ctrl_value, my_tol);
+
+      result_is_ok = (result_atanh_is_ok && result_is_ok);
+    }
+
+    return result_is_ok;
+  }
+
 } // namespace local
 
 auto main() -> int
@@ -279,6 +334,24 @@ auto main() -> int
     && result_edge_is_ok
     && result_is_ok
   );
+
+  {
+    using namespace boost::decimal;
+
+    const auto result_ctrl_is_ok =
+    (
+         local::test_atanh_ctrl<decimal32_t>      (16)
+      && local::test_atanh_ctrl<decimal64_t>      (16)
+      && local::test_atanh_ctrl<decimal128_t>     (16)
+      && local::test_atanh_ctrl<decimal_fast32_t> (16)
+      && local::test_atanh_ctrl<decimal_fast64_t> (16)
+      && local::test_atanh_ctrl<decimal_fast128_t>(16)
+    );
+
+    BOOST_TEST(result_ctrl_is_ok);
+
+    result_is_ok = (result_ctrl_is_ok && result_is_ok);
+  }
 
   result_is_ok = ((boost::report_errors() == 0) && result_is_ok);
 

--- a/test/test_log1p.cpp
+++ b/test/test_log1p.cpp
@@ -356,6 +356,85 @@ namespace local
     return result_is_ok;
   }
 
+  // These control values cover the full range of the series branch, for all
+  // six types. The random tests use decimal32_t and compare with float. Thus
+  // they cannot find an error that is smaller than the epsilon of float.
+  template<typename DecimalType>
+  auto test_log1p_wide(const int tol_factor) -> bool
+  {
+    using decimal_type = DecimalType;
+
+    using str_ctrl_array_type = std::array<const char*, 32U>;
+
+    const str_ctrl_array_type x_strings =
+    {{
+      "-0.999", "-0.99",  "-0.95",  "-0.9",
+      "-0.8",   "-0.75",  "-0.7",   "-0.6",
+      "-0.5",   "-0.45",  "-0.4",   "-0.35",
+      "-0.3",   "-0.25",  "-0.2",   "-0.15",
+      "-1e-12", "-1e-25", "1e-25",  "1e-12",
+      "0.15",   "0.2",    "0.25",   "0.3",
+      "0.35",   "0.4",    "0.45",   "0.5",
+      "0.55",   "0.75",   "1.0",    "2.0",
+    }};
+
+    const str_ctrl_array_type ctrl_strings =
+    {{
+      // Table[N[Log[1 + x], 36], {x, x_strings}]
+      "-6.90775527898213705205397436405309262",
+      "-4.60517018598809136803598290936872842",
+      "-2.99573227355399099343522357614254078",
+      "-2.30258509299404568401799145468436421",
+      "-1.60943791243410037460075933322618764",
+      "-1.38629436111989061883446424291635314",
+      "-1.2039728043259359926227462177618385",
+      "-0.916290731874155065183527211768011071",
+      "-0.693147180559945309417232121458176568",
+      "-0.597837000755620449373279998177411476",
+      "-0.510825623765990683205514096303661935",
+      "-0.430782916092454257381736134577222171",
+      "-0.356674943938732378912638711241184478",
+      "-0.287682072451780927439219005993827432",
+      "-0.223143551314209755766295090309834503",
+      "-0.16251892949777491318568895826941424",
+      "-0.00000000000100000000000050000000000033333333333",
+      "-0.000000000000000000000000100000000000000000000000005",
+      "0.000000000000000000000000099999999999999999999999995",
+      "0.000000000000999999999999500000000000333333333333",
+      "0.139761942375158697371529255667655343",
+      "0.182321556793954626211718025154514633",
+      "0.223143551314209755766295090309834503",
+      "0.262364264467491052035495986880954397",
+      "0.300104592450338080750512134625036338",
+      "0.33647223662121293050459341021699209",
+      "0.37156355643248303374804845621937083",
+      "0.405465108108164381978013115464349137",
+      "0.438254930931155252493940748399816435",
+      "0.559615787935422686270888500526826593",
+      "0.693147180559945309417232121458176568",
+      "1.0986122886681096913952452369225257",
+    }};
+
+    bool result_is_ok { true };
+
+    const decimal_type my_tol { std::numeric_limits<decimal_type>::epsilon() * static_cast<decimal_type>(tol_factor) };
+
+    for(auto i = static_cast<std::size_t>(UINT8_C(0)); i < std::tuple_size<str_ctrl_array_type>::value; ++i)
+    {
+      decimal_type x_arg      { };
+      decimal_type ctrl_value { };
+
+      static_cast<void>(from_chars(x_strings[i], x_strings[i] + std::strlen(x_strings[i]), x_arg));
+      static_cast<void>(from_chars(ctrl_strings[i], ctrl_strings[i] + std::strlen(ctrl_strings[i]), ctrl_value));
+
+      const auto result_log1p_is_ok = is_close_fraction(log1p(x_arg), ctrl_value, my_tol);
+
+      result_is_ok = (result_log1p_is_ok && result_is_ok);
+    }
+
+    return result_is_ok;
+  }
+
 } // namespace local
 
 auto main() -> int
@@ -366,17 +445,21 @@ auto main() -> int
 
   const auto result_narrow_is_ok = local::test_log1p(16, false, -0.375L, 0.375L);
 
+  const auto result_neg_is_ok = local::test_log1p(96, true, 0.0L, 0.95L);
+
   const auto result_pos_wide_is_ok = local::test_log1p(96, false, 1.0L, 1.0E6L);
 
   const auto result_edge_is_ok = local::test_log1p_edge();
 
   BOOST_TEST(result_pos_is_ok);
   BOOST_TEST(result_narrow_is_ok);
+  BOOST_TEST(result_neg_is_ok);
   BOOST_TEST(result_pos_wide_is_ok);
   BOOST_TEST(result_edge_is_ok);
 
   result_is_ok = (result_pos_is_ok      && result_is_ok);
   result_is_ok = (result_narrow_is_ok   && result_is_ok);
+  result_is_ok = (result_neg_is_ok      && result_is_ok);
   result_is_ok = (result_pos_wide_is_ok && result_is_ok);
   result_is_ok = (result_edge_is_ok     && result_is_ok);
 
@@ -394,6 +477,24 @@ auto main() -> int
     BOOST_TEST(result_pos128_is_ok);
 
     result_is_ok = (result_pos128_is_ok && result_is_ok);
+  }
+
+  {
+    using namespace boost::decimal;
+
+    const auto result_wide_is_ok =
+    (
+         local::test_log1p_wide<decimal32_t>      (16)
+      && local::test_log1p_wide<decimal64_t>      (16)
+      && local::test_log1p_wide<decimal128_t>     (16)
+      && local::test_log1p_wide<decimal_fast32_t> (16)
+      && local::test_log1p_wide<decimal_fast64_t> (16)
+      && local::test_log1p_wide<decimal_fast128_t>(16)
+    );
+
+    BOOST_TEST(result_wide_is_ok);
+
+    result_is_ok = (result_wide_is_ok && result_is_ok);
   }
 
   result_is_ok = ((boost::report_errors() == 0) && result_is_ok);


### PR DESCRIPTION
The log1p function calculated a Taylor polynomial of log(1 + x) for all values of x in the range (-1, 0.5]. The test had an upper limit at x = 0.5, but it had no lower limit. The coefficient tables were not long enough for this range.

The function gave a result with too few correct digits, and it reported no error. At x = -0.99, the relative error was 34 percent for decimal32_t. It was 25 percent for decimal64_t, and 16 percent for decimal128_t. All six types had this problem, because the fast types hold a copy of the same values.

The tables now hold the coefficients 2/(2k+1) of the series 2 * atanh(w), with w = x / (2 + x). The counts are 7, 16 and 34 terms, in place of 12, 20 and 36. For |x| not more than 1/2, the value of |w| is not more than 1/3. A test of abs(x) gives the lower limit that the code did not have. For all larger values of |x|, the code calculates log(x + 1).

For |x| less than 10^-digits10, the function now returns x. The sum of the terms after x is less than one half of the last digit of x. This branch also keeps w * w away from the exponents where fma gives an incorrect result for decimal32_t and decimal64_t. The exponents are 1e-21 to 1e-31 for decimal32_t, and 1e-42 to 1e-62 for decimal64_t.

A test with MPFR at 1610 points of the branch gives these results:

  decimal32_t    3.37e+05 eps -> 1.02 eps,   551 ns -> 478 ns
  decimal64_t    2.52e+14 eps -> 0.88 eps,  3299 ns -> 2613 ns
  decimal128_t   1.61e+32 eps -> 0.91 eps,  5291 ns -> 5291 ns

The largest error is now at x = -0.64. This point is in the branch that calculates log(x + 1), thus the value is the error of the log function.

The atanh, asinh and acosh functions call log1p. They get the correction with no change. For decimal128_t, the error of atanh at x = 0.49 decreases from 5.13e+19 eps to 0.23 eps. The error of acosh at x = 1.08 decreases from 6.45e+19 eps to 0.41 eps.

The old tests for these four functions used decimal32_t and compared with float. A test of this form cannot find an error that is smaller than the epsilon of float. The old tests also did not use values of x that are less than -0.375. Each test now has a table of control values with 36 digits, for all six types. The table for log1p has 32 points, and four of them are near zero. Each new test fails with the old code.

Fixes #1430.