### PR TITLE
Make log1p increase at every argument

### DIFF
--- a/include/boost/decimal/detail/cmath/impl/log1p_impl.hpp
+++ b/include/boost/decimal/detail/cmath/impl/log1p_impl.hpp
@@ -26,19 +26,18 @@ template <bool b>
 struct log1p_table_imp
 {
 private:
-    using d32_coeffs_t  = std::array<decimal32_t,   7>;
-    using d64_coeffs_t  = std::array<decimal64_t,  16>;
-    using d128_coeffs_t = std::array<decimal128_t, 34>;
+    using d32_coeffs_t  = std::array<decimal32_t,   6>;
+    using d64_coeffs_t  = std::array<decimal64_t,  15>;
+    using d128_coeffs_t = std::array<decimal128_t, 33>;
 
-    using d32_fast_coeffs_t  = std::array<decimal_fast32_t,   7>;
-    using d64_fast_coeffs_t  = std::array<decimal_fast64_t,  16>;
-    using d128_fast_coeffs_t = std::array<decimal_fast128_t, 34>;
+    using d32_fast_coeffs_t  = std::array<decimal_fast32_t,   6>;
+    using d64_fast_coeffs_t  = std::array<decimal_fast64_t,  15>;
+    using d128_fast_coeffs_t = std::array<decimal_fast128_t, 33>;
 
 public:
     static constexpr d32_coeffs_t d32_coeffs =
     {{
-         // Series[2*ArcTanh[w], {w, 0, 13}]
-         boost::decimal::decimal32_t { 2, 0 },                               // * w^1
+         // Series[2*ArcTanh[w], {w, 0, 13}], without the first term
          boost::decimal::decimal32_t { UINT64_C(6666666666666666667), -19 }, // * w^3
          boost::decimal::decimal32_t { UINT64_C(4000000000000000000), -19 }, // * w^5
          boost::decimal::decimal32_t { UINT64_C(2857142857142857143), -19 }, // * w^7
@@ -49,8 +48,7 @@ public:
 
     static constexpr d32_fast_coeffs_t d32_fast_coeffs =
     {{
-         // Series[2*ArcTanh[w], {w, 0, 13}]
-         boost::decimal::decimal_fast32_t { 2, 0 },                               // * w^1
+         // Series[2*ArcTanh[w], {w, 0, 13}], without the first term
          boost::decimal::decimal_fast32_t { UINT64_C(6666666666666666667), -19 }, // * w^3
          boost::decimal::decimal_fast32_t { UINT64_C(4000000000000000000), -19 }, // * w^5
          boost::decimal::decimal_fast32_t { UINT64_C(2857142857142857143), -19 }, // * w^7
@@ -61,8 +59,7 @@ public:
 
     static constexpr d64_coeffs_t d64_coeffs =
     {{
-         // Series[2*ArcTanh[w], {w, 0, 31}]
-         boost::decimal::decimal64_t { 2, 0 },                                   // * w^1
+         // Series[2*ArcTanh[w], {w, 0, 31}], without the first term
          boost::decimal::decimal64_t { UINT64_C(6666666666666666667), -19 },     // * w^3
          boost::decimal::decimal64_t { UINT64_C(4000000000000000000), -19 },     // * w^5
          boost::decimal::decimal64_t { UINT64_C(2857142857142857143), -19 },     // * w^7
@@ -82,8 +79,7 @@ public:
 
     static constexpr d64_fast_coeffs_t d64_fast_coeffs =
     {{
-         // Series[2*ArcTanh[w], {w, 0, 31}]
-         boost::decimal::decimal_fast64_t { 2, 0 },                                   // * w^1
+         // Series[2*ArcTanh[w], {w, 0, 31}], without the first term
          boost::decimal::decimal_fast64_t { UINT64_C(6666666666666666667), -19 },     // * w^3
          boost::decimal::decimal_fast64_t { UINT64_C(4000000000000000000), -19 },     // * w^5
          boost::decimal::decimal_fast64_t { UINT64_C(2857142857142857143), -19 },     // * w^7
@@ -103,8 +99,7 @@ public:
 
     static constexpr d128_coeffs_t d128_coeffs =
     {{
-         // Series[2*ArcTanh[w], {w, 0, 67}]
-         ::boost::decimal::decimal128_t { 2, 0 },                                                                                        // * w^1
+         // Series[2*ArcTanh[w], {w, 0, 67}], without the first term
          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(361400724161834), UINT64_C(14966504185106442923) }, -34 }, // * w^3
          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(216840434497100), UINT64_C(16358600140547686400) }, -34 }, // * w^5
          ::boost::decimal::decimal128_t { boost::int128::uint128_t { UINT64_C(154886024640786), UINT64_C(6414216079331332681) }, -34 },  // * w^7
@@ -142,8 +137,7 @@ public:
 
     static constexpr d128_fast_coeffs_t d128_fast_coeffs =
     {{
-         // Series[2*ArcTanh[w], {w, 0, 67}]
-         ::boost::decimal::decimal_fast128_t { 2, 0 },                                                                                        // * w^1
+         // Series[2*ArcTanh[w], {w, 0, 67}], without the first term
          ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(361400724161834), UINT64_C(14966504185106442923) }, -34 }, // * w^3
          ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(216840434497100), UINT64_C(16358600140547686400) }, -34 }, // * w^5
          ::boost::decimal::decimal_fast128_t { boost::int128::uint128_t { UINT64_C(154886024640786), UINT64_C(6414216079331332681) }, -34 },  // * w^7
@@ -206,41 +200,44 @@ constexpr typename log1p_table_imp<b>::d128_fast_coeffs_t log1p_table_imp<b>::d1
 
 using log1p_table = log1p_detail::log1p_table_imp<true>;
 
+// 2*atanh(w) = 2*w + (2/3)*w^3 + (2/5)*w^5 + ...
+// The first coefficient is exactly 2 for every type, thus the tables leave it out and
+// the caller adds that term itself. This gives the rest of the series, divided by w^3.
 template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto log1p_series_expansion(T z2) noexcept;
+constexpr auto log1p_series_tail(T z2) noexcept;
 
 template <>
-constexpr auto log1p_series_expansion<decimal32_t>(decimal32_t z2) noexcept
+constexpr auto log1p_series_tail<decimal32_t>(decimal32_t z2) noexcept
 {
     return taylor_series_result(z2, log1p_table::d32_coeffs);
 }
 
 template <>
-constexpr auto log1p_series_expansion<decimal_fast32_t>(decimal_fast32_t z2) noexcept
+constexpr auto log1p_series_tail<decimal_fast32_t>(decimal_fast32_t z2) noexcept
 {
     return taylor_series_result(z2, log1p_table::d32_fast_coeffs);
 }
 
 template <>
-constexpr auto log1p_series_expansion<decimal64_t>(decimal64_t z2) noexcept
+constexpr auto log1p_series_tail<decimal64_t>(decimal64_t z2) noexcept
 {
     return taylor_series_result(z2, log1p_table::d64_coeffs);
 }
 
 template <>
-constexpr auto log1p_series_expansion<decimal_fast64_t>(decimal_fast64_t z2) noexcept
+constexpr auto log1p_series_tail<decimal_fast64_t>(decimal_fast64_t z2) noexcept
 {
     return taylor_series_result(z2, log1p_table::d64_fast_coeffs);
 }
 
 template <>
-constexpr auto log1p_series_expansion<decimal128_t>(decimal128_t z2) noexcept
+constexpr auto log1p_series_tail<decimal128_t>(decimal128_t z2) noexcept
 {
     return taylor_series_result(z2, log1p_table::d128_coeffs);
 }
 
 template <>
-constexpr auto log1p_series_expansion<decimal_fast128_t>(decimal_fast128_t z2) noexcept
+constexpr auto log1p_series_tail<decimal_fast128_t>(decimal_fast128_t z2) noexcept
 {
     return taylor_series_result(z2, log1p_table::d128_fast_coeffs);
 }

--- a/include/boost/decimal/detail/cmath/log1p.hpp
+++ b/include/boost/decimal/detail/cmath/log1p.hpp
@@ -8,6 +8,7 @@
 
 #include <boost/decimal/fwd.hpp> // NOLINT(llvm-include-order)
 #include <boost/decimal/detail/cmath/abs.hpp>
+#include <boost/decimal/detail/cmath/fma.hpp>
 #include <boost/decimal/detail/cmath/impl/log1p_impl.hpp>
 #include <boost/decimal/detail/concepts.hpp>
 #include <boost/decimal/detail/config.hpp>
@@ -74,13 +75,27 @@ constexpr auto log1p_impl(const T x) noexcept
         }
         else
         {
-            // log1p(x) = 2 * atanh(w), with w = x / (2 + x).
-            // For |x| not more than 1/2, the value of |w| is not more than 1/3.
-            // The coefficient table covers this range. For all larger values
-            // of |x|, the first branch calculates log(x + 1).
-            const T w { x / (T { 2, 0 } + x) };
+            // log1p(x) = 2 * atanh(w), with w = x / (2 + x). For |x| not more than
+            // 1/2 the value of |w| is not more than 1/3, which the coefficient table
+            // covers. The first branch takes every larger |x| through log(x + 1).
+            // Two corrections make the result increase at every argument. The sum
+            // 2 + x is not exact, and its error makes the quotient fall where x rises,
+            // thus e holds that error and wh + wl holds the reduction to about two
+            // times the digits of the type. The first coefficient is exactly 2, thus
+            // 2*wh stays out of the rounding of the series and only tail rounds.
+            constexpr T two { 2, 0 };
 
-            result = w * detail::log1p_series_expansion(w * w);
+            const T d  { two + x };
+            const T e  { x - (d - two) };  // 2 + x == d + e, exact
+            const T wh { x / d };
+            const T r  { detail::unchecked_fma(-wh, d, x) - wh * e };
+            const T wl { r / d };
+
+            const T w    { wh + wl };
+            const T y    { w * w };
+            const T tail { w * y * detail::log1p_series_tail(y) };
+
+            result = detail::unchecked_fma(two, wh, detail::unchecked_fma(two, wl, tail));
         }
     }
 

--- a/test/test_log1p.cpp
+++ b/test/test_log1p.cpp
@@ -435,6 +435,57 @@ namespace local
     return result_is_ok;
   }
 
+  template<typename DecimalType>
+  auto test_log1p_monotonic(const char* type_name, const int pair_count) -> bool
+  {
+    using decimal_type = DecimalType;
+
+    // log1p increases at every argument, thus two adjacent values must not give
+    // results in the opposite order. Each walk stays below 0.5, the join of the two
+    // branches, which has a pair of its own that this test does not cover.
+
+    using start_array_type = std::array<decimal_type, 6U>;
+
+    const start_array_type start_values =
+    {{
+      decimal_type {  5, -2 }, decimal_type {  1, -1 }, decimal_type {  2, -1 },
+      decimal_type {  3, -1 }, decimal_type {  4, -1 }, decimal_type { 45, -2 },
+    }};
+
+    const decimal_type one { 1, 0 };
+
+    auto inversion_count = static_cast<std::uintmax_t>(UINT8_C(0));
+
+    for(auto i = static_cast<std::size_t>(UINT8_C(0)); i < std::tuple_size<start_array_type>::value; ++i)
+    {
+      decimal_type z    { start_values[i] };
+      decimal_type prev { log1p(z) };
+
+      for(auto n = 0; n < pair_count; ++n)
+      {
+        z = nextafter(z, one);
+
+        const decimal_type cur { log1p(z) };
+
+        if(cur < prev)
+        {
+          ++inversion_count;
+        }
+
+        prev = cur;
+      }
+    }
+
+    const bool result_is_ok { inversion_count == static_cast<std::uintmax_t>(UINT8_C(0)) };
+
+    if(!result_is_ok)
+    {
+      std::cout << "log1p is not monotonic for " << type_name << ": " << inversion_count << " inversions" << std::endl;
+    }
+
+    return result_is_ok;
+  }
+
 } // namespace local
 
 auto main() -> int
@@ -495,6 +546,27 @@ auto main() -> int
     BOOST_TEST(result_wide_is_ok);
 
     result_is_ok = (result_wide_is_ok && result_is_ok);
+  }
+
+  {
+    using namespace boost::decimal;
+
+    const auto result_mono_d32_is_ok   = local::test_log1p_monotonic<decimal32_t>      ("decimal32_t",       40000);
+    const auto result_mono_d64_is_ok   = local::test_log1p_monotonic<decimal64_t>      ("decimal64_t",       40000);
+    const auto result_mono_d128_is_ok  = local::test_log1p_monotonic<decimal128_t>     ("decimal128_t",       2000);
+    const auto result_mono_f32_is_ok   = local::test_log1p_monotonic<decimal_fast32_t> ("decimal_fast32_t",  40000);
+    const auto result_mono_f64_is_ok   = local::test_log1p_monotonic<decimal_fast64_t> ("decimal_fast64_t",  40000);
+    const auto result_mono_f128_is_ok  = local::test_log1p_monotonic<decimal_fast128_t>("decimal_fast128_t",  2000);
+
+    const auto result_monotonic_is_ok =
+    (
+         result_mono_d32_is_ok  && result_mono_d64_is_ok  && result_mono_d128_is_ok
+      && result_mono_f32_is_ok  && result_mono_f64_is_ok  && result_mono_f128_is_ok
+    );
+
+    BOOST_TEST(result_monotonic_is_ok);
+
+    result_is_ok = (result_monotonic_is_ok && result_is_ok);
   }
 
   result_is_ok = ((boost::report_errors() == 0) && result_is_ok);


### PR DESCRIPTION
The reduction w = x / (2 + x) rounds the sum 2 + x, and the error of that sum makes the quotient fall where x rises. The series then rounds at the size of 2, which puts the full size of the result through that rounding. Together these give pairs of adjacent arguments whose results are in the opposite order.

Two corrections remove both. The value e holds the error of the sum, and wh + wl holds the reduction to about two times the digits of the type. The first coefficient of the series is exactly 2 for every type, thus the tables now leave it out and the result adds 2*wh and 2*wl with a fused operation. Only the small value tail rounds at a small size.

test_log1p.cpp gets test_log1p_monotonic, which walks the same pairs for all six types.

Fix #1442