### PR TITLE
Make the remainder of a u256 divide by one word correct

### DIFF
--- a/include/boost/decimal/decimal_fast128_t.hpp
+++ b/include/boost/decimal/decimal_fast128_t.hpp
@@ -1071,10 +1071,11 @@ constexpr auto operator+(const decimal_fast128_t& rhs) noexcept -> decimal_fast1
     return rhs;
 }
 
-constexpr auto operator-(decimal_fast128_t rhs) noexcept -> decimal_fast128_t
+// A write to a by-value parameter which is then returned is dropped by the MSVC 19.29
+// optimizer, thus every sign change here builds a new value instead.
+constexpr auto operator-(const decimal_fast128_t rhs) noexcept -> decimal_fast128_t
 {
-    rhs.sign_ = !rhs.sign_;
-    return rhs;
+    return direct_init_d128(rhs.significand_, rhs.exponent_, !rhs.sign_);
 }
 
 constexpr auto operator+(const decimal_fast128_t& lhs, const decimal_fast128_t& rhs) noexcept -> decimal_fast128_t
@@ -1722,13 +1723,12 @@ constexpr decimal_fast128_t::operator Decimal() const noexcept
     return to_decimal<Decimal>(*this);
 }
 
-constexpr auto copysignd128f(decimal_fast128_t mag, const decimal_fast128_t sgn) noexcept -> decimal_fast128_t
+constexpr auto copysignd128f(const decimal_fast128_t mag, const decimal_fast128_t sgn) noexcept -> decimal_fast128_t
 {
-    mag.sign_ = sgn.sign_;
-    return mag;
+    return direct_init_d128(mag.significand_, mag.exponent_, sgn.sign_);
 }
 
-constexpr auto scalblnd128f(decimal_fast128_t num, const long exp) noexcept -> decimal_fast128_t
+constexpr auto scalblnd128f(const decimal_fast128_t num, const long exp) noexcept -> decimal_fast128_t
 {
     #ifndef BOOST_DECIMAL_FAST_MATH
     constexpr decimal_fast128_t zero {0, 0};
@@ -1739,9 +1739,7 @@ constexpr auto scalblnd128f(decimal_fast128_t num, const long exp) noexcept -> d
     }
     #endif
 
-    num = decimal_fast128_t(num.significand_, num.biased_exponent() + exp, num.sign_);
-
-    return num;
+    return decimal_fast128_t(num.significand_, num.biased_exponent() + exp, num.sign_);
 }
 
 constexpr auto scalbnd128f(const decimal_fast128_t num, const int exp) noexcept -> decimal_fast128_t

--- a/include/boost/decimal/decimal_fast32_t.hpp
+++ b/include/boost/decimal/decimal_fast32_t.hpp
@@ -1030,10 +1030,11 @@ constexpr auto operator+(const decimal_fast32_t rhs) noexcept -> decimal_fast32_
     return rhs;
 }
 
-constexpr auto operator-(decimal_fast32_t lhs) noexcept -> decimal_fast32_t
+// A write to a by-value parameter which is then returned is dropped by the MSVC 19.29
+// optimizer, thus every sign change here builds a new value instead.
+constexpr auto operator-(const decimal_fast32_t lhs) noexcept -> decimal_fast32_t
 {
-    lhs.sign_ = !lhs.sign_;
-    return lhs;
+    return direct_init(lhs.significand_, lhs.exponent_, !lhs.sign_);
 }
 
 constexpr auto operator+(const decimal_fast32_t lhs, const decimal_fast32_t rhs) noexcept -> decimal_fast32_t
@@ -1115,7 +1116,7 @@ constexpr auto operator+(const Integer lhs, const decimal_fast32_t rhs) noexcept
     return rhs + lhs;
 }
 
-constexpr auto operator-(const decimal_fast32_t lhs, decimal_fast32_t rhs) noexcept -> decimal_fast32_t
+constexpr auto operator-(const decimal_fast32_t lhs, const decimal_fast32_t rhs) noexcept -> decimal_fast32_t
 {
     #ifndef BOOST_DECIMAL_FAST_MATH
     if (!isfinite(lhs) || !isfinite(rhs))
@@ -1159,9 +1160,7 @@ constexpr auto operator-(const decimal_fast32_t lhs, decimal_fast32_t rhs) noexc
         }
     }
 
-    rhs.sign_ = !rhs.sign_;
-
-    return detail::add_impl<decimal_fast32_t>(lhs, rhs);
+    return detail::add_impl<decimal_fast32_t>(lhs, -rhs);
 }
 
 template <typename Integer>
@@ -1740,10 +1739,9 @@ constexpr auto scalbnd32f(const decimal_fast32_t num, const int expval) noexcept
     return scalblnd32f(num, static_cast<long>(expval));
 }
 
-constexpr auto copysignd32f(decimal_fast32_t mag, const decimal_fast32_t sgn) noexcept -> decimal_fast32_t
+constexpr auto copysignd32f(const decimal_fast32_t mag, const decimal_fast32_t sgn) noexcept -> decimal_fast32_t
 {
-    mag.sign_ = sgn.sign_;
-    return mag;
+    return direct_init(mag.significand_, mag.exponent_, sgn.sign_);
 }
 
 // Effects: determines if the quantum exponents of x and y are the same.

--- a/include/boost/decimal/decimal_fast64_t.hpp
+++ b/include/boost/decimal/decimal_fast64_t.hpp
@@ -1060,10 +1060,11 @@ constexpr auto operator+(const decimal_fast64_t val) noexcept -> decimal_fast64_
     return val;
 }
 
-constexpr auto operator-(decimal_fast64_t val) noexcept -> decimal_fast64_t
+// A write to a by-value parameter which is then returned is dropped by the MSVC 19.29
+// optimizer, thus every sign change here builds a new value instead.
+constexpr auto operator-(const decimal_fast64_t val) noexcept -> decimal_fast64_t
 {
-    val.sign_ = !val.sign_;
-    return val;
+    return direct_init_d64(val.significand_, val.exponent_, !val.sign_);
 }
 
 constexpr decimal_fast64_t::operator bool() const noexcept
@@ -1250,7 +1251,7 @@ constexpr auto operator+(const Integer lhs, const decimal_fast64_t rhs) noexcept
     return rhs + lhs;
 }
 
-constexpr auto operator-(const decimal_fast64_t lhs, decimal_fast64_t rhs) noexcept -> decimal_fast64_t
+constexpr auto operator-(const decimal_fast64_t lhs, const decimal_fast64_t rhs) noexcept -> decimal_fast64_t
 {
     #ifndef BOOST_DECIMAL_FAST_MATH
     if (not_finite(lhs) || not_finite(rhs))
@@ -1294,9 +1295,7 @@ constexpr auto operator-(const decimal_fast64_t lhs, decimal_fast64_t rhs) noexc
         }
     }
 
-    rhs.sign_ = !rhs.sign_;
-
-    return detail::add_impl<decimal_fast64_t>(lhs, rhs);
+    return detail::add_impl<decimal_fast64_t>(lhs, -rhs);
 }
 
 template <typename Integer>
@@ -1788,7 +1787,7 @@ constexpr auto quantexpd64f(const decimal_fast64_t x) noexcept -> int
     return x.biased_exponent();
 }
 
-constexpr auto scalblnd64f(decimal_fast64_t num, const long exp) noexcept -> decimal_fast64_t
+constexpr auto scalblnd64f(const decimal_fast64_t num, const long exp) noexcept -> decimal_fast64_t
 {
     #ifndef BOOST_DECIMAL_FAST_MATH
     constexpr decimal_fast64_t zero {0, 0};
@@ -1799,9 +1798,7 @@ constexpr auto scalblnd64f(decimal_fast64_t num, const long exp) noexcept -> dec
     }
     #endif
 
-    num = decimal_fast64_t(num.significand_, num.biased_exponent() + exp, num.sign_);
-
-    return num;
+    return decimal_fast64_t(num.significand_, num.biased_exponent() + exp, num.sign_);
 }
 
 constexpr auto scalbnd64f(const decimal_fast64_t num, const int expval) noexcept -> decimal_fast64_t
@@ -1809,10 +1806,9 @@ constexpr auto scalbnd64f(const decimal_fast64_t num, const int expval) noexcept
     return scalblnd64f(num, static_cast<long>(expval));
 }
 
-constexpr auto copysignd64f(decimal_fast64_t mag, const decimal_fast64_t sgn) noexcept -> decimal_fast64_t
+constexpr auto copysignd64f(const decimal_fast64_t mag, const decimal_fast64_t sgn) noexcept -> decimal_fast64_t
 {
-    mag.sign_ = sgn.sign_;
-    return mag;
+    return direct_init_d64(mag.significand_, mag.exponent_, sgn.sign_);
 }
 
 #if !defined(BOOST_DECIMAL_DISABLE_CLIB)

--- a/include/boost/decimal/detail/u256.hpp
+++ b/include/boost/decimal/detail/u256.hpp
@@ -1319,7 +1319,9 @@ BOOST_DECIMAL_FORCE_INLINE BOOST_DECIMAL_CUDA_CONSTEXPR auto div_mod(const u256&
             remainder = dividend % v[0];
         }
 
-        u[0] = static_cast<std::uint32_t>(remainder);
+        // Above word 0 the array u still holds the dividend, thus it is not the
+        // remainder. A remainder of a divide by one word needs only one word.
+        return {from_words(q), u256{remainder}};
     }
     else
     {

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -101,6 +101,7 @@ run github_issue_1424.cpp ;
 run github_issue_1436.cpp ;
 run github_issue_1437.cpp ;
 run github_issue_1440.cpp ;
+run github_issue_1447.cpp ;
 
 run link_1.cpp link_2.cpp link_3.cpp ;
 run quick.cpp ;

--- a/test/github_issue_1447.cpp
+++ b/test/github_issue_1447.cpp
@@ -1,0 +1,123 @@
+// Copyright 2026 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+//
+// https://github.com/boostorg/decimal/issues/1447
+//
+// The single word branch of impl::div_mod left the words above the lowest one with the
+// words of the dividend, thus a remainder of a shift of 1 to 9 digits came out wrong.
+
+#include <boost/decimal.hpp>
+#include <boost/decimal/detail/u256.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+using namespace boost::decimal;
+using namespace boost::decimal::literals;
+
+// 10^shift divides this dividend with no remainder for every shift from 1 to 9, and the
+// dividend stays above 2^32, thus more than one word holds it.
+void test_exact_division()
+{
+    const detail::u256 ten {UINT64_C(10)};
+
+    detail::u256 dividend {UINT64_C(9373841430626804)};
+    detail::u256 divisor {UINT64_C(1)};
+
+    for (int shift {1}; shift <= 9; ++shift)
+    {
+        dividend = dividend * ten;
+        divisor = divisor * ten;
+
+        const auto result {detail::impl::div_mod(dividend, divisor)};
+
+        BOOST_TEST(result.remainder == detail::u256{UINT64_C(0)});
+        BOOST_TEST(result.quotient * divisor == dividend);
+    }
+}
+
+// A remainder which is not zero must come through as itself. The quotient was correct
+// before the correction, thus only the remainder shows the defect.
+void test_inexact_division()
+{
+    const detail::u256 ten {UINT64_C(10)};
+
+    const detail::u256 dividend {UINT64_C(9373841430626804007)};
+    detail::u256 divisor {UINT64_C(1)};
+
+    for (int shift {1}; shift <= 9; ++shift)
+    {
+        divisor = divisor * ten;
+
+        const auto result {detail::impl::div_mod(dividend, divisor)};
+
+        BOOST_TEST(result.remainder < divisor);
+        BOOST_TEST(result.quotient * divisor + result.remainder == dividend);
+    }
+}
+
+// A tie which is exact goes to the even last digit. The exact x*y+z here is
+// -9.3738414306268045e-11, and the last digit of the value below the tie is 4.
+void test_fma_exact_tie()
+{
+    const auto x {-6.645514330428021e+01_DD};
+    const auto y {1.419781212105145e+02_DD};
+    const auto z {9.435176391117113e+03_DD};
+
+    BOOST_TEST_EQ(fma(x, y, z), -9.373841430626804e-11_DD);
+    BOOST_TEST_EQ(fma(-x, y, -z), 9.373841430626804e-11_DD);
+}
+
+// The type holds the exact value of x*y+z of each triple below, and no rounding mode
+// may move an exact result.
+void test_fma_exact_results()
+{
+    // fesetround changes the mode only when the library can find a constant evaluation.
+    #ifndef BOOST_DECIMAL_NO_CONSTEVAL_DETECTION
+
+    const auto x64 {-3.794224970655122e+03_DD};
+    const auto y64 {1.616581331280940e+03_DD};
+    const auto z64 {6.133673254240982e+06_DD};
+    const auto exact64 {-6.062798323197468e-08_DD};
+
+    const auto x128 {8.631676437904993259081658098560000e+01_DL};
+    const auto y128 {6.588286699825668036197412089736755e+00_DL};
+    const auto z128 {-5.686795907304806584806883802739733e+02_DL};
+    const auto exact128 {5.686751361164512835752045042445728e-27_DL};
+
+    const auto x128f {8.631676437904993259081658098560000e+01_DLF};
+    const auto y128f {6.588286699825668036197412089736755e+00_DLF};
+    const auto z128f {-5.686795907304806584806883802739733e+02_DLF};
+    const auto exact128f {5.686751361164512835752045042445728e-27_DLF};
+
+    const rounding_mode modes[] {rounding_mode::fe_dec_downward,
+                                 rounding_mode::fe_dec_upward,
+                                 rounding_mode::fe_dec_toward_zero,
+                                 rounding_mode::fe_dec_to_nearest,
+                                 rounding_mode::fe_dec_to_nearest_from_zero};
+
+    for (const auto mode : modes)
+    {
+        fesetround(mode);
+
+        BOOST_TEST_EQ(fma(x64, y64, z64), exact64);
+        BOOST_TEST_EQ(fma(-x64, y64, -z64), -exact64);
+        BOOST_TEST_EQ(fma(x128, y128, z128), exact128);
+        BOOST_TEST_EQ(fma(-x128, y128, -z128), -exact128);
+        BOOST_TEST_EQ(fma(x128f, y128f, z128f), exact128f);
+        BOOST_TEST_EQ(fma(-x128f, y128f, -z128f), -exact128f);
+    }
+
+    fesetround(rounding_mode::fe_dec_to_nearest);
+
+    #endif
+}
+
+int main()
+{
+    test_exact_division();
+    test_inexact_division();
+    test_fma_exact_tie();
+    test_fma_exact_results();
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
- The single word branch of impl::div_mod wrote the remainder in word 0 of the array of
  the dividend. The words above word 0 kept the dividend, thus from_words gave the
  dividend back with its lowest 32 bits replaced.
- One 32 bit word holds the divisors 10^1 to 10^9. From 10^10 the divisor needs two
  words, thus the Knuth path runs, and that path writes the full remainder.
- The rounding reads the remainder to learn whether a digit which is not zero went away.
  A wrong remainder moves an exact result one step away from zero.
- The branch now gives the remainder from its own accumulator. It removes a store and it
  adds no work.
- fma of decimal64_t, decimal_fast64_t, decimal128_t and decimal_fast128_t gives the sum
  to the constructor as a u256, thus it had the defect.

Fixes #1447

