### PR TITLE
Round a sum of far apart operands by the sign of the result

### DIFF
--- a/include/boost/decimal/detail/add_impl.hpp
+++ b/include/boost/decimal/detail/add_impl.hpp
@@ -362,104 +362,40 @@ BOOST_DECIMAL_CUDA_CONSTEXPR auto add_impl(const T& lhs, const T& rhs) noexcept 
                                     ReturnType{lhs.full_significand(), lhs.biased_exponent(), lhs.isneg()} :
                                     ReturnType{rhs.full_significand(), rhs.biased_exponent(), rhs.isneg()};
             }
-            else if (round == rounding_mode::fe_dec_downward)
+
+            // The direction of a mode depends on the sign of the result: upward on a negative
+            // result goes toward zero. Away from zero adds one to big, toward zero takes one.
+            const bool use_lhs {lhs_exp > rhs_exp};
+            const bool neg {use_lhs ? lhs.isneg() : rhs.isneg()};
+            const bool away {round == (neg ? rounding_mode::fe_dec_downward : rounding_mode::fe_dec_upward)};
+            auto big {use_lhs ? big_lhs : big_rhs};
+            auto big_exp {use_lhs ? lhs_exp : rhs_exp};
+
+            if (lhs.isneg() == rhs.isneg())
             {
-                // If we are subtracting even disparate numbers we need to round down
-                // E.g. "5e+95"_DF - "4e-100"_DF == "4.999999e+95"_DF
-                const auto use_lhs {big_lhs != 0U && (lhs_exp > rhs_exp)};
-
-                // Need to check for the case where we have 1e+95 - anything = 9.99999... without losing a nine
-                if (use_lhs)
+                // E.g. 5e+95 + 4e-100 is 5.000001e+95 away from zero and 5e+95 toward it
+                if (away)
                 {
-                    if (big_rhs != 0U && (lhs.isneg() != rhs.isneg()))
-                    {
-                        if (is_power_of_10(big_lhs))
-                        {
-                            --big_lhs;
-                            big_lhs *= 10U;
-                            big_lhs += 9U;
-                            --lhs_exp;
-                        }
-                        else
-                        {
-                            --big_lhs;
-                        }
-                    }
-
-                    return ReturnType{big_lhs, lhs_exp, lhs.isneg()};
+                    ++big;
+                }
+            }
+            else if (!away)
+            {
+                // E.g. 1e+95 - 4e-100 is 9.999999e+94 toward zero, thus a power of ten needs a digit
+                if (is_power_of_10(big))
+                {
+                    --big;
+                    big *= 10U;
+                    big += 9U;
+                    --big_exp;
                 }
                 else
                 {
-                    if (big_lhs != 0U && (lhs.isneg() != rhs.isneg()))
-                    {
-                        if (is_power_of_10(big_rhs))
-                        {
-                            --big_rhs;
-                            big_rhs *= 10U;
-                            big_rhs += 9U;
-                            --rhs_exp;
-                        }
-                        else
-                        {
-                            --big_rhs;
-                        }
-                    }
-
-                    return ReturnType{big_rhs, rhs_exp, rhs.isneg()};
+                    --big;
                 }
             }
-            else
-            {
-                // rounding mode == fe_dec_upward
-                // Unconditionally round up. Could be 5e+95 + 4e-100 -> 5.000001e+95
-                const bool use_lhs {big_lhs != 0U && (lhs_exp > rhs_exp)};
 
-                if (use_lhs)
-                {
-                    if (big_rhs != 0U)
-                    {
-                        if (lhs.isneg() != rhs.isneg())
-                        {
-                            if (is_power_of_10(big_lhs))
-                            {
-                                --big_lhs;
-                                big_lhs *= 10U;
-                                big_lhs += 9U;
-                                --lhs_exp;
-                            }
-                            else
-                            {
-                                --big_lhs;
-                            }
-                        }
-                        else
-                        {
-                            ++big_lhs;
-                        }
-                    }
-
-                    return ReturnType{big_lhs, lhs_exp, lhs.isneg()} ;
-                }
-                else
-                {
-                    if (big_lhs != 0U)
-                    {
-                        if (rhs.isneg() != lhs.isneg())
-                        {
-                            --big_rhs;
-                            big_rhs *= 10U;
-                            big_rhs += 9U;
-                            --rhs_exp;
-                        }
-                        else
-                        {
-                            ++big_rhs;
-                        }
-                    }
-
-                    return ReturnType{big_rhs, rhs_exp, rhs.isneg()};
-                }
-            }
+            return ReturnType{big, big_exp, neg};
         }
 
         if (lhs_exp < rhs_exp)
@@ -610,104 +546,40 @@ BOOST_DECIMAL_CUDA_CONSTEXPR auto d128_add_impl_new(const T& lhs, const T& rhs) 
                                     ReturnType{lhs.full_significand(), lhs.biased_exponent(), lhs.isneg()} :
                                     ReturnType{rhs.full_significand(), rhs.biased_exponent(), rhs.isneg()};
             }
-            else if (round == rounding_mode::fe_dec_downward)
+
+            // The direction of a mode depends on the sign of the result: upward on a negative
+            // result goes toward zero. Away from zero adds one to big, toward zero takes one.
+            const bool use_lhs {lhs_exp > rhs_exp};
+            const bool neg {use_lhs ? lhs.isneg() : rhs.isneg()};
+            const bool away {round == (neg ? rounding_mode::fe_dec_downward : rounding_mode::fe_dec_upward)};
+            auto big {use_lhs ? big_lhs : big_rhs};
+            auto big_exp {use_lhs ? lhs_exp : rhs_exp};
+
+            if (lhs.isneg() == rhs.isneg())
             {
-                // If we are subtracting even disparate numbers we need to round down
-                // E.g. "5e+95"_DF - "4e-100"_DF == "4.999999e+95"_DF
-                const auto use_lhs {big_lhs != 0U && (lhs_exp > rhs_exp)};
-
-                // Need to check for the case where we have 1e+95 - anything = 9.99999... without losing a nine
-                if (use_lhs)
+                // E.g. 5e+95 + 4e-100 is 5.000001e+95 away from zero and 5e+95 toward it
+                if (away)
                 {
-                    if (big_rhs != 0U && (lhs.isneg() != rhs.isneg()))
-                    {
-                        if (is_power_of_10(big_lhs))
-                        {
-                            --big_lhs;
-                            big_lhs *= 10U;
-                            big_lhs += 9U;
-                            --lhs_exp;
-                        }
-                        else
-                        {
-                            --big_lhs;
-                        }
-                    }
-
-                    return ReturnType{big_lhs, lhs_exp, lhs.isneg()};
+                    ++big;
+                }
+            }
+            else if (!away)
+            {
+                // E.g. 1e+95 - 4e-100 is 9.999999e+94 toward zero, thus a power of ten needs a digit
+                if (is_power_of_10(big))
+                {
+                    --big;
+                    big *= 10U;
+                    big += 9U;
+                    --big_exp;
                 }
                 else
                 {
-                    if (big_lhs != 0U && (lhs.isneg() != rhs.isneg()))
-                    {
-                        if (is_power_of_10(big_rhs))
-                        {
-                            --big_rhs;
-                            big_rhs *= 10U;
-                            big_rhs += 9U;
-                            --rhs_exp;
-                        }
-                        else
-                        {
-                            --big_rhs;
-                        }
-                    }
-
-                    return ReturnType{big_rhs, rhs_exp, rhs.isneg()};
+                    --big;
                 }
             }
-            else
-            {
-                // rounding mode == fe_dec_upward
-                // Unconditionally round up. Could be 5e+95 + 4e-100 -> 5.000001e+95
-                const bool use_lhs {big_lhs != 0U && (lhs_exp > rhs_exp)};
 
-                if (use_lhs)
-                {
-                    if (big_rhs != 0U)
-                    {
-                        if (lhs.isneg() != rhs.isneg())
-                        {
-                            if (is_power_of_10(big_lhs))
-                            {
-                                --big_lhs;
-                                big_lhs *= 10U;
-                                big_lhs += 9U;
-                                --lhs_exp;
-                            }
-                            else
-                            {
-                                --big_lhs;
-                            }
-                        }
-                        else
-                        {
-                            ++big_lhs;
-                        }
-                    }
-
-                    return ReturnType{big_lhs, lhs_exp, lhs.isneg()} ;
-                }
-                else
-                {
-                    if (big_lhs != 0U)
-                    {
-                        if (rhs.isneg() != lhs.isneg())
-                        {
-                            --big_rhs;
-                            big_rhs *= 10U;
-                            big_rhs += 9U;
-                            --rhs_exp;
-                        }
-                        else
-                        {
-                            ++big_rhs;
-                        }
-                    }
-
-                    return ReturnType{big_rhs, rhs_exp, rhs.isneg()};
-                }
-            }
+            return ReturnType{big, big_exp, neg};
         }
 
         const auto shift_pow10 {detail::pow10_256(shift)};

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -102,6 +102,7 @@ run github_issue_1436.cpp ;
 run github_issue_1437.cpp ;
 run github_issue_1440.cpp ;
 run github_issue_1447.cpp ;
+run github_issue_1451.cpp ;
 
 run link_1.cpp link_2.cpp link_3.cpp ;
 run quick.cpp ;

--- a/test/github_issue_1035.cpp
+++ b/test/github_issue_1035.cpp
@@ -34,14 +34,14 @@ int main()
     fesetround(rounding_mode::fe_dec_downward);
     BOOST_TEST_EQ("5e+50"_DF * dist(rng) - "4e+40"_DF, "4.999999e+50"_DF);
     BOOST_TEST_EQ("5e+95"_DF * dist(rng)  - "4e-100"_DF, "4.999999e+95"_DF);
-    BOOST_TEST_EQ("-5e+95"_DF * dist(rng)  + "4e-100"_DF, "-4.999999e+95"_DF);
-    BOOST_TEST_EQ("-5e+95"_DL * dist(rng)  + "4e-100"_DL, "-4.999999999999999999999999999999999e+95"_DL);
+    BOOST_TEST_EQ("-5e+95"_DF * dist(rng)  + "4e-100"_DF, "-5e+95"_DF);
+    BOOST_TEST_EQ("-5e+95"_DL * dist(rng)  + "4e-100"_DL, "-5e+95"_DL);
 
     fesetround(rounding_mode::fe_dec_upward);
     BOOST_TEST_EQ("5e+50"_DF * dist(rng) + "4e+40"_DF, "5.000001e+50"_DF);
     BOOST_TEST_EQ("5e+95"_DF * dist(rng)  + "4e-100"_DF, "5.000001e+95"_DF);
-    BOOST_TEST_EQ("-5e+95"_DF * dist(rng)  - "4e-100"_DF, "-5.000001e+95"_DF);
-    BOOST_TEST_EQ("-5e+95"_DL * dist(rng)  - "4e-100"_DL, "-5.000000000000000000000000000000001e+95"_DL);
+    BOOST_TEST_EQ("-5e+95"_DF * dist(rng)  - "4e-100"_DF, "-5e+95"_DF);
+    BOOST_TEST_EQ("-5e+95"_DL * dist(rng)  - "4e-100"_DL, "-5e+95"_DL);
 
     return boost::report_errors();
 

--- a/test/github_issue_1451.cpp
+++ b/test/github_issue_1451.cpp
@@ -1,0 +1,96 @@
+// Copyright 2026 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+//
+// https://github.com/boostorg/decimal/issues/1451
+//
+// The far apart branch of add_impl rounded the magnitude of the result and not its value,
+// thus a directed mode went the wrong way when the result was negative.
+
+#include <boost/decimal.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+using namespace boost::decimal;
+using namespace boost::decimal::literals;
+
+// fesetround changes the mode only when the library can find a constant evaluation.
+#ifndef BOOST_DECIMAL_NO_CONSTEVAL_DETECTION
+
+// The two orders of the operands go through two copies of the branch, and operator-
+// flips the sign of the right operand on its own way into add_impl.
+template <typename T>
+void check(const rounding_mode mode, const T lhs, const T rhs, const T expected)
+{
+    fesetround(mode);
+    BOOST_TEST_EQ(lhs + rhs, expected);
+    BOOST_TEST_EQ(rhs + lhs, expected);
+    BOOST_TEST_EQ(lhs - (-rhs), expected);
+    BOOST_TEST_EQ(rhs - (-lhs), expected);
+}
+
+// tiny is too far below big to change its digits, thus it only selects the direction.
+// above and below are the neighbours of big, and every value here is exact.
+template <typename T>
+void test_directed_sums(const T big, const T tiny, const T above, const T below)
+{
+    check(rounding_mode::fe_dec_upward, big, tiny, above);
+    check(rounding_mode::fe_dec_upward, big, -tiny, big);
+    check(rounding_mode::fe_dec_upward, -big, -tiny, -big);
+    check(rounding_mode::fe_dec_upward, -big, tiny, -below);
+
+    check(rounding_mode::fe_dec_downward, big, tiny, big);
+    check(rounding_mode::fe_dec_downward, big, -tiny, below);
+    check(rounding_mode::fe_dec_downward, -big, -tiny, -above);
+    check(rounding_mode::fe_dec_downward, -big, tiny, -big);
+
+    check(rounding_mode::fe_dec_toward_zero, big, tiny, big);
+    check(rounding_mode::fe_dec_toward_zero, big, -tiny, below);
+    check(rounding_mode::fe_dec_toward_zero, -big, -tiny, -big);
+    check(rounding_mode::fe_dec_toward_zero, -big, tiny, -below);
+}
+
+// The exact x*y+z is -5693498000000000000000000000000000.000...000189, thus the downward
+// mode must give the value below -5.693498e+33, and the upward mode that value itself.
+void test_fma()
+{
+    fesetround(rounding_mode::fe_dec_downward);
+    BOOST_TEST_EQ(fma(-4.872580e-23_DF, 3.879349e-03_DF, -5.693498e+33_DF), -5.693499e+33_DF);
+    BOOST_TEST_EQ(fma(-4.872580e-23_DFF, 3.879349e-03_DFF, -5.693498e+33_DFF), -5.693499e+33_DFF);
+    BOOST_TEST_EQ(fma(-4.872580e-23_DD, 3.879349e-03_DD, -5.693498e+33_DD), -5.693498000000001e+33_DD);
+    BOOST_TEST_EQ(fma(-4.872580e-23_DDF, 3.879349e-03_DDF, -5.693498e+33_DDF), -5.693498000000001e+33_DDF);
+
+    fesetround(rounding_mode::fe_dec_upward);
+    BOOST_TEST_EQ(fma(-4.872580e-23_DF, 3.879349e-03_DF, -5.693498e+33_DF), -5.693498e+33_DF);
+    BOOST_TEST_EQ(fma(-4.872580e-23_DFF, 3.879349e-03_DFF, -5.693498e+33_DFF), -5.693498e+33_DFF);
+    BOOST_TEST_EQ(fma(-4.872580e-23_DD, 3.879349e-03_DD, -5.693498e+33_DD), -5.693498e+33_DD);
+    BOOST_TEST_EQ(fma(-4.872580e-23_DDF, 3.879349e-03_DDF, -5.693498e+33_DDF), -5.693498e+33_DDF);
+}
+
+#endif
+
+int main()
+{
+    #ifndef BOOST_DECIMAL_NO_CONSTEVAL_DETECTION
+
+    // 1 is a power of ten and 5 is not, thus the two go through the two paths of a decrement.
+    test_directed_sums(1_DF, 1e-50_DF, 1.000001_DF, 9.999999e-01_DF);
+    test_directed_sums(5_DF, 1e-50_DF, 5.000001_DF, 4.999999_DF);
+    test_directed_sums(1_DD, 1e-50_DD, 1.000000000000001_DD, 9.999999999999999e-01_DD);
+    test_directed_sums(5_DD, 1e-50_DD, 5.000000000000001_DD, 4.999999999999999_DD);
+    test_directed_sums(1_DL, 1e-50_DL, 1.000000000000000000000000000000001_DL, 9.999999999999999999999999999999999e-01_DL);
+    test_directed_sums(5_DL, 1e-50_DL, 5.000000000000000000000000000000001_DL, 4.999999999999999999999999999999999_DL);
+    test_directed_sums(1_DFF, 1e-50_DFF, 1.000001_DFF, 9.999999e-01_DFF);
+    test_directed_sums(5_DFF, 1e-50_DFF, 5.000001_DFF, 4.999999_DFF);
+    test_directed_sums(1_DDF, 1e-50_DDF, 1.000000000000001_DDF, 9.999999999999999e-01_DDF);
+    test_directed_sums(5_DDF, 1e-50_DDF, 5.000000000000001_DDF, 4.999999999999999_DDF);
+    test_directed_sums(1_DLF, 1e-50_DLF, 1.000000000000000000000000000000001_DLF, 9.999999999999999999999999999999999e-01_DLF);
+    test_directed_sums(5_DLF, 1e-50_DLF, 5.000000000000000000000000000000001_DLF, 4.999999999999999999999999999999999_DLF);
+
+    test_fma();
+
+    fesetround(rounding_mode::fe_dec_to_nearest);
+
+    #endif
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
- The far apart branch of add_impl rounded the magnitude of the dominant operand and not
  the value of the sum. Upward on a negative result went away from zero, and downward on a
  negative result went toward zero.
- The upward branch also took one from a positive result which shrinks, and its copy for
  the right operand had no check for a power of ten.
- One block now selects the dominant operand, reads the sign of the result, and moves the
  magnitude away from zero or toward zero as the mode asks.
- Four expectations of test/github_issue_1035.cpp held the wrong direction for a negative
  result. They now hold the value which IEEE 754-2019 4.3.2 asks for.

Fixes #1451

